### PR TITLE
fix install path

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ clean:
 
 # vars
 SHELL := /bin/bash
-INSTALL_ROOT ?= /asdf
+INSTALL_ROOT ?= /
 
 # lists
 hs_files = src/Main.hs


### PR DESCRIPTION
It fails to build as it is with the 
`install -m 755 apexctl /asdf/usr/local/bin/apexctl`
`install: cannot create regular file '/asdf/usr/local/bin/apexctl': No such file or directory`
`makefile:54: recipe for target 'install' failed`
`make: *** [install] Error 1`

This fixes that.